### PR TITLE
README のインストールの項目を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ manaba+R をほんの少し改善 (increment) する **非公式** Google Chrome
 1. 拡張機能ページ (Google Chrome では `chrome://extensions`) を開く
 2. ページ右上の <kbd>Developer mode</kbd> トグルスイッチをオンにし、ページをリロードする
 3. ダウンロードしたビルド済み zip ファイルを展開する
-4. <kbd>Load unpacked</kbd> / <kbd>パッケージ化されていない拡張機能を読み込む</kbd> から展開したフォルダを選択する
+4. 展開後のディレクトリに移動し、以下のコマンドを実行
+  ```shell
+  yarn && yarn build
+  ```
+5. <kbd>Load unpacked</kbd> / <kbd>パッケージ化されていない拡張機能を読み込む</kbd> からビルドで生成した `dist` フォルダを選択する
 
 ## 開発
 


### PR DESCRIPTION
些細な内容かもしれませんがご確認お願いします〜 🙌

## 内容
- mac での問題かもしれないが、解凍後のフォルダを `パッケージ化されていない拡張機能を読み込む` から読み込んだ際、以下のエラーが発生
  ![スクリーンショット 2021-04-12 0 46 53](https://user-images.githubusercontent.com/38882716/114311159-97a37080-9b28-11eb-9799-01ee5925c860.png)
- ビルド後、吐き出された `dist` を読み込むと正常に動作したので docs を修正
